### PR TITLE
Allow directory upload only on mac

### DIFF
--- a/app/windows/Storage/Components/Header.jsx
+++ b/app/windows/Storage/Components/Header.jsx
@@ -19,7 +19,11 @@ class Header extends React.Component {
   _handleAddButtonClick () {
     const selectOptions = {
       title: 'Add File',
-      properties: ['openFile', 'openDirectory', 'multiSelections']
+      properties: ['openFile', 'multiSelections']
+    }
+
+    if(process.platform === 'darwin') {
+      selectOptions.properties.push('openDirectory')
     }
 
     const paths = remote.dialog.showOpenDialog(remote.app.mainWindow, selectOptions)


### PR DESCRIPTION
Technically you can upload directories because of the multi select, but you can't upload just one directory.