### PR TITLE
Feature/11 windows support

### DIFF
--- a/app/daemon.js
+++ b/app/daemon.js
@@ -8,7 +8,7 @@ import pjson from '../package.json'
  * getPathIPFSBinary will return the IPFS default path
  */
 export function getPathIPFSBinary () {
-  return Settings.getSync('daemon.pathIPFSBinary') || '/usr/local/bin/ipfs'
+  return Settings.getSync('daemon.pathIPFSBinary') || 'ipfs'
 }
 
 /**
@@ -16,10 +16,13 @@ export function getPathIPFSBinary () {
  * return a promise with child process of IPFS daemon
  */
 export function startIPFSDaemon () {
+  // TODO: the default of this is undefined, therefore the default is to start the daemon
   if (Settings.getSync('daemon.startIPFSAtStartup') === false) { return Promise.resolve() }
 
   return new Promise((resolve, reject) => {
     const binaryPath = getPathIPFSBinary()
+    // TODO: this promise should reject on error
+    // https://nodejs.org/docs/latest/api/child_process.html#child_process_event_error
     const ipfsProcess = spawn(binaryPath, ['daemon'])
 
     ipfsProcess.stdout.on('data', (data) => console.log(`IPFS: ${data}`))

--- a/app/daemon.test.js
+++ b/app/daemon.test.js
@@ -18,7 +18,7 @@ describe('daemon.js', () => {
       const path = daemon.getPathIPFSBinary()
       // assert
       expect(Settings.getSync).toHaveBeenCalledWith('daemon.pathIPFSBinary')
-      expect(path).toBe('/usr/local/bin/ipfs')
+      expect(path).toBe('ipfs')
     })
 
     it('should return the setting when it is defined', () => {

--- a/app/windows/ResolveIPNS/window.js
+++ b/app/windows/ResolveIPNS/window.js
@@ -28,9 +28,9 @@ module.exports.create = function createResolveIPNSWindow (app) {
     modal: true,
 
     width: 430,
-    height: 175,
+    height: 225,
     minWidth: 300,
-    minHeight: 175,
+    minHeight: 225,
 
     maximizable: false,
     resizable: true,

--- a/app/windows/Settings/Components/DaemonPanel.jsx
+++ b/app/windows/Settings/Components/DaemonPanel.jsx
@@ -70,7 +70,7 @@ class DaemonPanel extends React.Component {
             type="text"
             defaultValue={data.pathIPFSBinary || getPathIPFSBinary()}
             onChange={this._handleChangePathIPFSBinary}
-            placeholder="/usr/local/bin/ipfs duh"
+            placeholder="ipfs"
           />
 
           <CheckBox

--- a/app/windows/Storage/window.js
+++ b/app/windows/Storage/window.js
@@ -22,7 +22,7 @@ module.exports = {}
 module.exports.create = function createStorageWindow (app) {
   // Create the browser window.
   let theWindow = new BrowserWindowClass({
-    width: 700,
+    width: 725,
     height: 450,
     minWidth: 400,
     minHeight: 300,

--- a/docs/RUN.md
+++ b/docs/RUN.md
@@ -15,6 +15,13 @@ Ubuntu Linux Users instead needs specific packages to be installed:
 # apt-get install libgtkextra-dev libgconf2-dev libnss3 libasound2 libxtst-dev
 ```
 
+Windows users need to install the [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) package, which comes with
+Visual C++ Build Tools and Python 2.7:
+
+```
+npm install --global --production windows-build-tools
+```
+
 ## Clone the source
 First of all you need to clone the source code and install
 the modules. Run the following commands to do so:


### PR DESCRIPTION
Windows installation requires the `windows-build-tools` package (because `node-gyp` needs python and some .net dependencies). 

Besides this, I had to install `go-ipfs`, add it to the `PATH` and change the code to use `ipfs` not `/usr/local/bin/ipfs` which I think we can safely change and assume ipfs will be in the path for unix users as well.

Building the distributable for windows did not work, it was taking more than 15 min so I killed it.

Other than that and a few minor UI "bugs" with the scrollbar and window sizes, it looks alright. Drap-and-drop, download, open in browser, they all work, even the icon.

![lumpy_windows](https://user-images.githubusercontent.com/26041347/37862968-63e71cb0-2f56-11e8-9a45-bde5d1772453.png)
